### PR TITLE
Fixed Daynix URL

### DIFF
--- a/html/data/c/daynix.json
+++ b/html/data/c/daynix.json
@@ -15,12 +15,12 @@
         "C",
         "C++",
         "Cloud Computing",
-	"Containers",
+        "Containers",
         "Linux Kernel",
         "Python",
         "Ruby",
         "Virtualization",
         "Windows Drivers"
     ],
-    "url": "http://http://www.daynix.com"
+    "url": "http://www.daynix.com"
 }


### PR DESCRIPTION
Daynix URL was inserted falsely with "http://" twice.

Signed-off-by: Basil Salman <basil@daynix.com>